### PR TITLE
Fix/refactor loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 # [3.0.0](https://github.com/BBVAEngineering/ember-task-scheduler/compare/v2.3.0...v3.0.0) (2021-07-21)
 
-
 ### Features
 
-* migrate to octane ([2d57144](https://github.com/BBVAEngineering/ember-task-scheduler/commit/2d5714493894848634e9e9f327d000729a12eead))
-
+- migrate to octane ([2d57144](https://github.com/BBVAEngineering/ember-task-scheduler/commit/2d5714493894848634e9e9f327d000729a12eead))
 
 ### BREAKING CHANGES
 
-* add support for ember-qunit@5
+- add support for ember-qunit@5
 
 # [2.3.0](https://github.com/BBVAEngineering/ember-task-scheduler/compare/v2.2.0...v2.3.0) (2021-01-14)
 

--- a/addon/services/scheduler.js
+++ b/addon/services/scheduler.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import Service from '@ember/service';
-import { begin, end } from '@ember/runloop';
+import { run } from '@ember/runloop';
 import { assert, warn } from '@ember/debug';
 import { getOwner } from '@ember/application';
 import { buildWaiter } from '@ember/test-waiters';
@@ -419,9 +419,7 @@ export default class SchedulerService extends Service {
       startTime = performance.now();
     }
 
-    begin();
-    exec(target, method, args, onError, stack);
-    end();
+    run(() => exec(target, method, args, onError, stack));
 
     /* istanbul ignore next */
     if (env === 'development') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1180,18 +1180,7 @@
     ember-cli-htmlbars "^5.7.1"
     ember-destroyable-polyfill "^2.0.3"
 
-"@ember/test-waiters@^2.4.4":
-  version "2.4.5"
-  resolved "https://registry.npmjs.org/@ember/test-waiters/-/test-waiters-2.4.5.tgz"
-  integrity sha512-833JvHtHdEfBfKXgvmw+6oziFOpVfD4NQrc04Ztj59A11K9FPNfZ3P8YydL7LFTtdd7UfJ/cYCLAm+OwUxbotQ==
-  dependencies:
-    calculate-cache-key-for-tree "^2.0.0"
-    ember-cli-babel "^7.26.6"
-    ember-cli-typescript "^4.1.0"
-    ember-cli-version-checker "^5.1.2"
-    semver "^7.3.5"
-
-"@ember/test-waiters@^2.4.5":
+"@ember/test-waiters@^2.4.4", "@ember/test-waiters@^2.4.5":
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/@ember/test-waiters/-/test-waiters-2.4.5.tgz#6e8e34d1bc46a9b0cc22cb11cc5936046e926031"
   integrity sha512-833JvHtHdEfBfKXgvmw+6oziFOpVfD4NQrc04Ztj59A11K9FPNfZ3P8YydL7LFTtdd7UfJ/cYCLAm+OwUxbotQ==


### PR DESCRIPTION
Remove `begin|end` to be able to migrate to `ember-beta`.