### PR TITLE
allow v3 of @ember/test-waiters

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "validate-coverage": "test \"$(cat coverage/coverage-summary.json | json total.lines.total)\" -gt 0"
   },
   "dependencies": {
-    "@ember/test-waiters": "^2.4.5",
+    "@ember/test-waiters": "^2.4.5 || ^3.0.1",
     "ember-cli-babel": "^7.26.6"
   },
   "devDependencies": {


### PR DESCRIPTION
This allows consuming app safely use v2 or v3 of `@ember/test-waiters`.

Currently, if app uses `@ember/test-waiters` v3, there is no guarantee which version will get into final build and may cause issues.